### PR TITLE
Simplify Type Metadata

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -22,11 +22,11 @@ jobs:
       - uses: denoland/setup-deno@v1
         with:
           deno-version: v1.x
-      # - run: deno lint
+      - run: deno lint
       - uses: actions/cache@v3
         with:
           path: ~/.cache/deno
           key: cache-${{ hashFiles('import_map.json') }}
       - run: deno task check
-      # - run: deno test
+      - run: deno test
 

--- a/core/Bool.ts
+++ b/core/Bool.ts
@@ -14,7 +14,7 @@ export class bool extends Type.make("bool")<BoolSource, boolean, never, never> {
     return new bool(new BoolSource.Not({ not: this }))
   }
 
-  assert<E extends Type>(error: E): Effect<E, never> {
+  assert<E extends Type>(_error: E): Effect<E, never> {
     unimplemented()
   }
 }
@@ -27,7 +27,7 @@ export class If<Y extends Yield, R extends Result> extends Effect<Y, R | None> {
     super()
   }
 
-  else<Y2 extends Yield>(f: () => Generator<Y2, R>): Effect<Y | Y2, R> {
+  else<Y2 extends Yield>(_f: () => Generator<Y2, R>): Effect<Y | Y2, R> {
     unimplemented()
   }
 }

--- a/core/Bool.ts
+++ b/core/Bool.ts
@@ -1,4 +1,5 @@
 import { Tagged } from "../util/Tagged.ts"
+import { unimplemented } from "../util/unimplemented.ts"
 import { Result, Yield } from "./CommandLike.ts"
 import { Effect } from "./Effect.ts"
 import { None } from "./None.ts"
@@ -14,8 +15,7 @@ export class bool extends Type.make("bool")<BoolSource, boolean, never, never> {
   }
 
   assert<E extends Type>(error: E): Effect<E, never> {
-    throw 0
-    // return new AssertNode(this, error).instance()
+    unimplemented()
   }
 }
 
@@ -28,7 +28,7 @@ export class If<Y extends Yield, R extends Result> extends Effect<Y, R | None> {
   }
 
   else<Y2 extends Yield>(f: () => Generator<Y2, R>): Effect<Y | Y2, R> {
-    throw 0
+    unimplemented()
   }
 }
 

--- a/core/Bytes.ts
+++ b/core/Bytes.ts
@@ -1,7 +1,9 @@
 import { Type } from "./Type.ts"
 
 export function Bytes<Size extends number>(size: Size) {
-  return class extends Type.make("Bytes", { size })<BytesSource, Uint8Array> {}
+  return class extends Type.make("Bytes")<BytesSource, Uint8Array> {
+    size = size
+  }
 }
 
 export type BytesSource = never

--- a/core/Call.ts
+++ b/core/Call.ts
@@ -1,3 +1,4 @@
+import { unimplemented } from "../util/unimplemented.ts"
 import { CommandLike, Result, Yield } from "./CommandLike.ts"
 import { Effect } from "./Effect.ts"
 
@@ -7,7 +8,7 @@ export function call<Y extends Yield, R extends Result>(g: Generator<Y, R>): Eff
 export function call<R extends Result>(f: () => R): Effect<never, R>
 export function call<Y extends Yield, R extends Result>(f: () => Generator<Y, R>): Effect<Y, R>
 export function call<Y extends Yield, R extends Result>(
-  value: CommandLike<Y, R>,
+  _value: CommandLike<Y, R>,
 ): Effect<Yield, Result> {
-  throw 0
+  unimplemented()
 }

--- a/core/Constant.ts
+++ b/core/Constant.ts
@@ -5,7 +5,9 @@ export interface Constant<T extends keyof any>
 {}
 
 export function Constant<T extends keyof any>(value: T) {
-  return class extends Type.make("Constant", { value })<ConstantSource, T> {}
+  return class extends Type.make("Constant")<ConstantSource, T> {
+    value = value
+  }
 }
 
 export type ConstantSource = never

--- a/core/Effect.ts
+++ b/core/Effect.ts
@@ -1,3 +1,4 @@
+import { unimplemented } from "../util/unimplemented.ts"
 import { Result, Yield } from "./CommandLike.ts"
 import { Factory } from "./Type.ts"
 
@@ -5,25 +6,26 @@ export class Effect<Y extends Yield, R extends Result> implements Generator<Y, R
   "" = {} as { node: unknown }
 
   pipe<R2 extends Result>(f: (value: R) => R2): Effect<Y, R2> {
-    throw 0
+    unimplemented()
   }
 
   next(): IteratorResult<Y, R> {
-    throw 0
+    unimplemented()
   }
 
   return(): IteratorResult<Y, R> {
-    throw 0
+    unimplemented()
   }
 
   throw(): IteratorResult<Y, R> {
-    throw 0
+    unimplemented()
   }
 
   [Symbol.iterator](): Generator<Y, R> {
-    throw 0
+    unimplemented()
   }
 
+  // TODO: fix this
   handle<M extends Factory<Y>, R extends Result>(
     match: M,
     f: R | ((matched: InstanceType<M>) => R),
@@ -33,8 +35,8 @@ export class Effect<Y extends Yield, R extends Result> implements Generator<Y, R
     f: (value: InstanceType<M>) => Generator<Y2, R>,
   ): [Exclude<Y, InstanceType<M>> | Y2] extends [never] ? R
     : Effect<Exclude<Y, InstanceType<M>> | Y2, R>
-  {
-    throw 0
+  handle(_match: any, _f: any): any {
+    unimplemented()
   }
 
   // TODO: fix this
@@ -42,7 +44,7 @@ export class Effect<Y extends Yield, R extends Result> implements Generator<Y, R
     match: M,
   ): [Exclude<Y, InstanceType<M>>] extends [never] ? InstanceType<M> | R
     : Effect<Exclude<Y, InstanceType<M>>, R>
-  {
-    throw 0
+  rehandle(_match: any): any {
+    unimplemented()
   }
 }

--- a/core/Effect.ts
+++ b/core/Effect.ts
@@ -5,7 +5,7 @@ import { Factory } from "./Type.ts"
 export class Effect<Y extends Yield, R extends Result> implements Generator<Y, R> {
   "" = {} as { node: unknown }
 
-  pipe<R2 extends Result>(f: (value: R) => R2): Effect<Y, R2> {
+  pipe<R2 extends Result>(_f: (value: R) => R2): Effect<Y, R2> {
     unimplemented()
   }
 

--- a/core/Hash.ts
+++ b/core/Hash.ts
@@ -4,7 +4,10 @@ export function Hash<T extends Type, A extends HashAlgorithm>(
   targetType: Factory<T>,
   algorithm: A,
 ) {
-  return Type.make("Hash", { targetType, algorithm })<HashSource, Uint8Array, never, never>
+  return class extends Type.make("Hash")<HashSource, Uint8Array, never, never> {
+    targetType = targetType
+    algorithm = algorithm
+  }
 }
 
 export type HashAlgorithm =

--- a/core/Id.ts
+++ b/core/Id.ts
@@ -1,4 +1,5 @@
 import { Tagged } from "../util/Tagged.ts"
+import { unimplemented } from "../util/unimplemented.ts"
 import { Effect } from "./Effect.ts"
 import { u64 } from "./Int.ts"
 import { State } from "./State.ts"
@@ -15,29 +16,29 @@ export namespace IdSource {
 }
 
 export class id extends Type.make("id")<IdSource, Uint8Array, Uint8Array> {
-  static fromHex(hex: string): id {
-    throw 0
+  static fromHex(_hex: string): id {
+    unimplemented()
   }
 
-  static fromBytes(bytes: Uint8Array): id {
-    throw 0
+  static fromBytes(_bytes: Uint8Array): id {
+    unimplemented()
   }
 
-  bind<N>(namespace: N): Contract<N> {
-    throw 0
+  bind<N>(_namespace: N): Contract<N> {
+    unimplemented()
   }
 
-  signer<K extends string>(key: K): SignerEffect<K> {
-    throw 0
+  signer<K extends string>(_key: K): SignerEffect<K> {
+    unimplemented()
   }
 }
 
 export class SignerEffect<K extends string> extends Effect<SignerRequirement<K>, signer<K>> {
   deploy<N>(
-    namespace: N,
-    deployOptions: DeployOptions<N>,
+    _namespace: N,
+    _deployOptions: DeployOptions<N>,
   ): Generator<SignerRequirement<K>, Contract<N>> {
-    throw 0
+    unimplemented()
   }
 }
 
@@ -57,12 +58,15 @@ export function signer<K extends keyof any>(key: K) {
   return class extends id {
     readonly key = key
 
-    deploy<N>(namespace: N, deployOptions: DeployOptions<N>): Generator<never, Contract<N>> {
-      throw 0
+    deploy<N>(
+      _namespace: N,
+      _deployOptions: DeployOptions<N>,
+    ): Generator<never, Contract<N>> {
+      unimplemented()
     }
 
-    send(props: SendProps): Effect<never, never> {
-      throw 0
+    send(_props: SendProps): Effect<never, never> {
+      unimplemented()
     }
   }
 }

--- a/core/Int.ts
+++ b/core/Int.ts
@@ -29,13 +29,15 @@ export type IntSize = 8 | 16 | 32 | 64 | 128 | 256
 
 function Int<Signed extends boolean, Size extends IntSize>(signed: Signed, size: Size) {
   return class<From extends Type, Into extends Type, ExtraSource = never>
-    extends Type.make(`${signed ? "i" : "u"}${size}`, { signed })<
+    extends Type.make(`${signed ? "i" : "u"}${size}`)<
       IntSource | ExtraSource,
       number,
       number | From,
       Into
     >
   {
+    signed = signed
+
     static min<This extends Factory>(this: This) {
       return new this(new IntSource.Min())
     }

--- a/core/MerkleList.ts
+++ b/core/MerkleList.ts
@@ -1,5 +1,6 @@
 import { MerkleList as MerkleListNative } from "../lib/mod.ts"
 import { Tagged } from "../util/Tagged.ts"
+import { unimplemented } from "../util/unimplemented.ts"
 import { Effect } from "./Effect.ts"
 import { u256, U256Source } from "./Int.ts"
 import { Factory, Type } from "./Type.ts"
@@ -9,12 +10,14 @@ export interface MerkleList<T extends Type = Type>
 {}
 
 export function MerkleList<T extends Type>(elementType: Factory<T>) {
-  return class extends Type.make("MerkleList", { elementType })<
+  return class extends Type.make("MerkleList")<
     MerkleListSource,
     MerkleListNative<Type.Native<T>>,
     undefined,
     never
   > {
+    elementType = elementType
+
     length: u256 = new u256(new U256Source.MerkleListSize(this))
 
     first = this.at(u256.new(1))
@@ -42,10 +45,10 @@ export function MerkleList<T extends Type>(elementType: Factory<T>) {
     }
 
     reduceKeys<R extends Type, Y extends Type>(
-      initial: R,
-      f: (acc: R, cur: T) => Generator<Y, R>,
+      _initial: R,
+      _f: (acc: R, cur: T) => Generator<Y, R>,
     ): Effect<R, Y> {
-      throw 0
+      unimplemented()
     }
   }
 }

--- a/core/MerkleMap.ts
+++ b/core/MerkleMap.ts
@@ -1,5 +1,6 @@
 import { MerkleMap as MerkleMapNative } from "../lib/mod.ts"
 import { Tagged } from "../util/Tagged.ts"
+import { unimplemented } from "../util/unimplemented.ts"
 import { Effect } from "./Effect.ts"
 import { u256, U256Source } from "./Int.ts"
 import { None } from "./None.ts"
@@ -13,11 +14,14 @@ export function MerkleMap<K extends Type, V extends Type>(
   keyType: Factory<K>,
   valueType: Factory<V>,
 ) {
-  return class extends Type.make("MerkleMap", { keyType, valueType })<
+  return class extends Type.make("MerkleMap")<
     MerkleMapSource,
     MerkleMapNative<Type.Native<K>, Type.Native<V>>,
     undefined
   > {
+    keyType = keyType
+    valueType = valueType
+
     size: u256 = new u256(new U256Source.MerkleMapSize(this))
 
     set(key: K, value: V): MerkleMap<K, V> {
@@ -33,24 +37,24 @@ export function MerkleMap<K extends Type, V extends Type>(
     }
 
     reduceKeys<R extends Type, Y extends Type>(
-      initial: R,
-      f: (acc: R, cur: K) => Generator<Y, R>,
+      _initial: R,
+      _f: (acc: R, cur: K) => Generator<Y, R>,
     ): Effect<R, Y> {
-      throw 0
+      unimplemented()
     }
 
     reduceValues<R extends Type, Y extends Type>(
-      initial: R,
-      f: (acc: R, cur: V) => Generator<Y, R>,
+      _initial: R,
+      _f: (acc: R, cur: V) => Generator<Y, R>,
     ): Effect<R, Y> {
-      throw 0
+      unimplemented()
     }
 
     reduceEntries<R extends Type, Y extends Type>(
-      initial: R,
-      f: (acc: R, cur: [K, V]) => Generator<Y, R>,
+      _initial: R,
+      _f: (acc: R, cur: [K, V]) => Generator<Y, R>,
     ): Effect<R, Y> {
-      throw 0
+      unimplemented()
     }
   }
 }

--- a/core/State.ts
+++ b/core/State.ts
@@ -1,9 +1,19 @@
+import { unimplemented } from "../util/unimplemented.ts"
 import { Effect } from "./Effect.ts"
-import { Type } from "./Type.ts"
+import { Factory, Type } from "./Type.ts"
 
 export type State<T extends Type = any> = {
-  type: "state"
+  type: "State"
   (): Effect<never, T>
   (newValue: T): Effect<never, T>
   (f: (oldValue: T) => T): Effect<never, T>
+}
+
+export function State<T extends Type>(_type: Factory<T>): State<T> {
+  return Object.assign(
+    { type: "State" },
+    (_valueOrF: T | ((oldValue: T) => T)): Effect<never, T> => {
+      unimplemented()
+    },
+  ) as State<T>
 }

--- a/core/Struct.ts
+++ b/core/Struct.ts
@@ -8,9 +8,9 @@ export interface Struct<F extends FieldTypes = any>
 {}
 
 export function Struct<const F extends FieldTypes>(fieldTypes: F) {
-  return class
-    extends Type.make("Struct", { fieldTypes })<StructSource, StructNative<F>, Fields<F>>
-  {
+  return class extends Type.make("Struct")<StructSource, StructNative<F>, Fields<F>> {
+    fieldTypes = fieldTypes
+
     fields = Object.fromEntries(
       Object.entries(fieldTypes).map(([key, type]) => [
         key,

--- a/core/Tx.ts
+++ b/core/Tx.ts
@@ -1,6 +1,7 @@
 import { Client, TxBroadcast, TxFinalization, TxInclusion, TxStatus } from "../client/Client.ts"
 import { SignalOptions } from "../util/AbortController.ts"
 import { Subscription } from "../util/Subscription.ts"
+import { unimplemented } from "../util/unimplemented.ts"
 import { CommandLike, Result, Yield } from "./CommandLike.ts"
 import { SignerRequirement } from "./Id.ts"
 import { Type } from "./Type.ts"
@@ -36,7 +37,7 @@ export class SignedTx<Y extends Yield, R extends Result> {
     this.signers = signers
   }
 
-  run(handler?: TxHandler<Y>): TxRun<Y, R> {
+  run(_handler?: TxHandler<Y>): TxRun<Y, R> {
     return new TxRun(this)
   }
 }
@@ -46,8 +47,8 @@ export type TxHandler<Y extends Yield> = (value: Type.Native<Exclude<Y, SignerRe
 export class TxRun<Y extends Yield, R extends Result> {
   constructor(readonly signedTx: SignedTx<Y, R>) {}
 
-  commit(chain: Client, options?: CommitOptions): Commit<Type.Native<R>> {
-    throw 0
+  commit(_chain: Client, _options?: CommitOptions): Commit<Type.Native<R>> {
+    unimplemented()
   }
 }
 

--- a/core/Type.ts
+++ b/core/Type.ts
@@ -1,5 +1,6 @@
 import { Rest } from "../util/Rest.ts"
 import { Tagged } from "../util/Tagged.ts"
+import { unimplemented } from "../util/unimplemented.ts"
 import { bool, BoolSource } from "./Bool.ts"
 import { Result, Yield } from "./CommandLike.ts"
 import { Effect } from "./Effect.ts"
@@ -9,21 +10,17 @@ export type Factory<T extends Type = any> = new(source: any) => T
 
 export class Type<
   Name extends string = any,
-  Metadata = any,
   Source = any,
   Native = any,
   From = any,
   Into extends Type = any,
 > {
-  static make<Name extends string, Metadata = undefined>(
-    name: Name,
-    metadata: Metadata = undefined!,
-  ) {
+  static make<Name extends string>(name: Name) {
     return class<Source, Native, From = Native, Into extends Type = never>
-      extends this<Name, Metadata, Source, Native, From, Into>
+      extends this<Name, Source, Native, From, Into>
     {
       constructor(source: Source | TypeSource) {
-        super(name, metadata, source)
+        super(name, source)
       }
     }
   }
@@ -33,12 +30,11 @@ export class Type<
   }
 
   static state<T extends Type>(this: Factory<T>): State<T> {
-    throw 0
+    unimplemented()
   }
 
   "": {
     name: Name
-    metadata: Metadata
     source: Source | TypeSource
     native?: [Native]
     from?: [From]
@@ -47,8 +43,8 @@ export class Type<
 
   protected ctor = this.constructor as any
 
-  constructor(name: Name, metadata: Metadata, source: Source | TypeSource) {
-    this[""] = { name, metadata, source }
+  constructor(name: Name, source: Source | TypeSource) {
+    this[""] = { name, source }
   }
 
   into<O extends Into>(into: Factory<O>): O {
@@ -85,8 +81,8 @@ export class Type<
     match: M,
     f: (matched: InstanceType<M>) => R | Generator<Y, R>,
   ): Effect<Y, U>
-  match(match: any, f: any): any {
-    throw 0
+  match(_match: any, _f: any): any {
+    unimplemented()
   }
 
   unhandle<T extends Type, M extends Factory<T>>(
@@ -104,17 +100,17 @@ export class Type<
   ): Effect<W, Exclude<T, InstanceType<M>>>
   unhandle(
     this: Type,
-    match: Factory,
-    maybeWith_?: Type | Factory,
-    ...rest: Factory[]
+    _match: Factory,
+    _maybeWith_?: Type | Factory,
+    ..._rest: Factory[]
   ): Effect<Type, Type> {
-    throw 0
+    unimplemented()
   }
 }
 
 export declare namespace Type {
-  export type From<T> = T extends Type<any, any, any, any, infer From> ? From : never
-  export type Native<T extends Type | void> = T extends Type<any, any, any, infer N> ? N : undefined
+  export type From<T> = T extends Type<any, any, any, infer From> ? From : never
+  export type Native<T extends Type | void> = T extends Type<any, any, infer N> ? N : undefined
 }
 
 export type TypeSource = TypeSource.New | TypeSource.Into | TypeSource.StructField

--- a/import_map.json
+++ b/import_map.json
@@ -1,4 +1,7 @@
 {
+  "imports": {
+    "@std/assert": "jsr:@std/assert@^0.225.1"
+  },
   "scopes": {
     "examples/": {
       "liminal": "./mod.ts",

--- a/parser/mod.test.ts
+++ b/parser/mod.test.ts
@@ -1,0 +1,5 @@
+import { assertEquals } from "@std/assert"
+
+Deno.test("noop", () => {
+  assertEquals(true, true)
+})

--- a/parser/testing.ts
+++ b/parser/testing.ts
@@ -1,2 +1,2 @@
-import * as ERC20 from "../examples/Erc20/Erc20.contract.ts"
-import * as L from "../mod.ts"
+import * as _ERC20 from "../examples/Erc20/Erc20.contract.ts"
+import * as _L from "../mod.ts"


### PR DESCRIPTION
Store directly on instance, instead of within the `""` field of the base `Type` class.

```ts
function SomeWrapper<T extends Type>(type: Factory<T>) {
  return class extends Type("SomeWrapper", { type }) {}
}
```

Becomes...

```ts
function SomeWrapper<T extends Type>(type: Factory<T>) {
  return class extends Type("SomeWrapper") {
    type = type
  }
}
```

This will simplify operating on a given value (also simplifies the typing, as we get rid of the `Metadata` type param).

---

Also, reenables linting and testing in checks workflow