### PR TITLE
Union Runtime Representation

### DIFF
--- a/core/Int.ts
+++ b/core/Int.ts
@@ -51,53 +51,43 @@ function Int<Signed extends boolean, Size extends IntSize>(signed: Signed, size:
     }
 
     add(value: this): this {
-      // @ts-ignore .
-      return new this.constructor(new IntSource.Add(this, value))
+      return new this.ctor(new IntSource.Add(this, value))
     }
 
     subtract(value: this): this {
-      // @ts-ignore .
-      return new this.constructor(new IntSource.Subtract(this, value))
+      return new this.ctor(new IntSource.Subtract(this, value))
     }
 
     multiply(value: this): this {
-      // @ts-ignore .
-      return new this.constructor(new IntSource.Multiply(this, value))
+      return new this.ctor(new IntSource.Multiply(this, value))
     }
 
     divide(value: this): this {
-      // @ts-ignore .
-      return new this.constructor(new IntSource.Divide(this, value))
+      return new this.ctor(new IntSource.Divide(this, value))
     }
 
     square(): this {
-      // @ts-ignore .
-      return new this.constructor(new IntSource.Square(this))
+      return new this.ctor(new IntSource.Square(this))
     }
 
     logarithm(value: this): this {
-      // @ts-ignore .
-      return new this.constructor(new IntSource.Logarithm(this, value))
+      return new this.ctor(new IntSource.Logarithm(this, value))
     }
 
     gt(value: this): bool {
-      // @ts-ignore .
-      return new this.constructor(new IntSource.Gt(this, value))
+      return new this.ctor(new IntSource.Gt(this, value)) as never
     }
 
     gte(value: this): bool {
-      // @ts-ignore .
-      return new this.constructor(new IntSource.Gte(this, value))
+      return new this.ctor(new IntSource.Gte(this, value)) as never
     }
 
     lt(value: this): bool {
-      // @ts-ignore .
-      return new this.constructor(new IntSource.Lt(this, value))
+      return new this.ctor(new IntSource.Lt(this, value)) as never
     }
 
     lte(value: this): bool {
-      // @ts-ignore .
-      return new this.constructor(new IntSource.Lte(this, value))
+      return new this.ctor(new IntSource.Lte(this, value)) as never
     }
   }
 }

--- a/core/MerkleList.ts
+++ b/core/MerkleList.ts
@@ -3,7 +3,9 @@ import { Tagged } from "../util/Tagged.ts"
 import { unimplemented } from "../util/unimplemented.ts"
 import { Effect } from "./Effect.ts"
 import { u256, U256Source } from "./Int.ts"
+import { None } from "./None.ts"
 import { Factory, Type } from "./Type.ts"
+import { Union } from "./Union.ts"
 
 export interface MerkleList<T extends Type = Type>
   extends InstanceType<ReturnType<typeof MerkleList<T>>>
@@ -25,28 +27,23 @@ export function MerkleList<T extends Type>(elementType: Factory<T>) {
     last = this.at(this.length.subtract(u256.new(1)))
 
     prepend(value: T): MerkleList<T> {
-      // @ts-ignore .
-      return new this.constructor(new MerkleListSource.Prepend({ list: this, value }))
+      return new this.ctor(new MerkleListSource.Prepend(this, value))
     }
 
     append(value: T): MerkleList<T> {
-      // @ts-ignore .
-      return new this.constructor(new MerkleListSource.Append({ list: this, value }))
+      return new this.ctor(new MerkleListSource.Append(this, value))
     }
 
     shift(): MerkleList<T> {
-      // @ts-ignore .
-      return new this.constructor(new MerkleListSource.Shift(this))
+      return new this.ctor(new MerkleListSource.Shift(this))
     }
 
     pop(): MerkleList<T> {
-      // @ts-ignore .
-      return new this.constructor(new MerkleListSource.Pop(this))
+      return new this.ctor(new MerkleListSource.Pop(this))
     }
 
-    at(index: u256): T {
-      // @ts-ignore .
-      return new this.constructor(new MerkleListSource.At({ list: this, index }))
+    at(index: u256): T | None {
+      return new (Union([None, this.elementType]))(new MerkleListSource.At(this, index)) as never
     }
 
     reduceKeys<R extends Type, Y extends Type>(

--- a/core/MerkleMap.ts
+++ b/core/MerkleMap.ts
@@ -5,6 +5,7 @@ import { Effect } from "./Effect.ts"
 import { u256, U256Source } from "./Int.ts"
 import { None } from "./None.ts"
 import { Factory, Type } from "./Type.ts"
+import { Union } from "./Union.ts"
 
 export interface MerkleMap<K extends Type = Type, V extends Type = Type>
   extends InstanceType<ReturnType<typeof MerkleMap<K, V>>>
@@ -25,18 +26,15 @@ export function MerkleMap<K extends Type, V extends Type>(
     size: u256 = new u256(new U256Source.MerkleMapSize(this))
 
     set(key: K, value: V): MerkleMap<K, V> {
-      // @ts-ignore .
-      return new this.constructor(new MerkleMapSource.Set({ map: this, key, value }))
+      return new this.ctor(new MerkleMapSource.Set(this, key, value))
     }
 
     delete(key: K): MerkleMap<K, V> {
-      // @ts-ignore .
-      return new this.constructor(new MerkleMapSource.Delete({ map: this, key }))
+      return new this.ctor(new MerkleMapSource.Delete(this, key))
     }
 
     get(key: K): V | None {
-      // @ts-ignore .
-      return new this.constructor(new MerkleMapSource.Get({ map: this, key }))
+      return new (Union([None, this.keyType]))(new MerkleMapSource.Get(this, key)) as never
     }
 
     reduceKeys<R extends Type, Y extends Type>(

--- a/core/Type.ts
+++ b/core/Type.ts
@@ -37,6 +37,8 @@ export class Type<
 
   constructor(readonly typeName: Name, readonly source: Source | TypeSource) {}
 
+  ctor = this.constructor as never as new(source: Source | TypeSource) => this
+
   into<O extends Into>(into: Factory<O>): O {
     return new into(new TypeSource.Into({ from: this }))
   }
@@ -89,13 +91,14 @@ export class Type<
     _maybeWith_?: Type | Factory<T>,
     ..._rest: Factory<T>[]
   ) {
-    unimplemented()
+    return unimplemented()
   }
 }
 
 export declare namespace Type {
   export type From<T> = T extends Type<any, any, any, infer From> ? From : never
   export type Native<T extends Type | void> = T extends Type<any, any, infer N> ? N : undefined
+  export type Source<T extends Type> = T extends Type<any, infer S> ? S : never
 }
 
 export type TypeSource = TypeSource.New | TypeSource.Into | TypeSource.StructField

--- a/core/Union.ts
+++ b/core/Union.ts
@@ -1,0 +1,11 @@
+import { MerkleListSource } from "./MerkleList.ts"
+import { MerkleMapSource } from "./MerkleMap.ts"
+import { Factory, Type } from "./Type.ts"
+
+export function Union<T extends Factory[]>(members: [...T]) {
+  return class extends Type.make("Union")<UnionSource, Type.Native<InstanceType<T[number]>>> {
+    members = members
+  }
+}
+
+export type UnionSource = MerkleMapSource.Get | MerkleListSource.At

--- a/core/mod.ts
+++ b/core/mod.ts
@@ -1,4 +1,4 @@
-// moderate
+// moderate --exclude Union.ts
 
 export * from "./Bool.ts"
 export * from "./Branch.ts"


### PR DESCRIPTION
The signature of Liminal unions comes close to native TypeScript types. For instance, we represent an optional u256 as `None | u256` (somewhat parallel to `undefined | number`). Since all types have the `match` method, you can call `match` on any union. However, the runtime representation is less obvious. Under the hood, any method-returned union (aka. not supplied by the contract caller) will return a an instance of `Union([...types])` and then `as` it to the cleaner signature. This is useful in cases such as a list element retrieval:

```ts
at(index: u256): T | None
```

The runtime implementation (for now) looks as follows.

```ts
at(index: u256): T | None {
  return new (Union([None, this.elementType]))(new MerkleListSource.At(this, index)) as never
}
```