### PR TITLE
Union Type Cleanup

### DIFF
--- a/core/MerkleList.ts
+++ b/core/MerkleList.ts
@@ -5,7 +5,7 @@ import { Effect } from "./Effect.ts"
 import { u256, U256Source } from "./Int.ts"
 import { None } from "./None.ts"
 import { Factory, Type } from "./Type.ts"
-import { Union } from "./Union.ts"
+import { union } from "./Union.ts"
 
 export interface MerkleList<T extends Type = Type>
   extends InstanceType<ReturnType<typeof MerkleList<T>>>
@@ -43,7 +43,7 @@ export function MerkleList<T extends Type>(elementType: Factory<T>) {
     }
 
     at(index: u256): T | None {
-      return new (Union([None, this.elementType]))(new MerkleListSource.At(this, index)) as never
+      return union([None, this.elementType], new MerkleListSource.At(this, index))
     }
 
     reduceKeys<R extends Type, Y extends Type>(

--- a/core/MerkleMap.ts
+++ b/core/MerkleMap.ts
@@ -5,7 +5,7 @@ import { Effect } from "./Effect.ts"
 import { u256, U256Source } from "./Int.ts"
 import { None } from "./None.ts"
 import { Factory, Type } from "./Type.ts"
-import { Union } from "./Union.ts"
+import { union } from "./Union.ts"
 
 export interface MerkleMap<K extends Type = Type, V extends Type = Type>
   extends InstanceType<ReturnType<typeof MerkleMap<K, V>>>
@@ -34,7 +34,7 @@ export function MerkleMap<K extends Type, V extends Type>(
     }
 
     get(key: K): V | None {
-      return new (Union([None, this.keyType]))(new MerkleMapSource.Get(this, key)) as never
+      return union([None, this.valueType], new MerkleMapSource.Get(this, key))
     }
 
     reduceKeys<R extends Type, Y extends Type>(

--- a/core/Union.ts
+++ b/core/Union.ts
@@ -2,8 +2,12 @@ import { MerkleListSource } from "./MerkleList.ts"
 import { MerkleMapSource } from "./MerkleMap.ts"
 import { Factory, Type } from "./Type.ts"
 
-export function Union<T extends Factory[]>(members: [...T]) {
-  return class extends Type.make("Union")<UnionSource, Type.Native<InstanceType<T[number]>>> {
+export function union<T extends Factory[]>(members: [...T], source: UnionSource) {
+  return new (Union(...members))(source) as InstanceType<T[number]>
+}
+
+export function Union<T extends Factory[]>(...members: T) {
+  return class Union extends Type.make("Union")<UnionSource, Type.Native<InstanceType<T[number]>>> {
     members = members
   }
 }


### PR DESCRIPTION
- create `union` util for simpler properly-typed anonymous unions
- fix incorrect type supplied to `MerkleMap` get's union