### PR TITLE
Renames and Type Fixes

### DIFF
--- a/client/Tx.ts
+++ b/client/Tx.ts
@@ -1,4 +1,4 @@
-import { Branch, Result, Yield } from "../core/Branch.ts"
+import { Call, Result, Yield } from "../core/Call.ts"
 import { SignerRequirement } from "../core/Id.ts"
 import { Type } from "../core/Type.ts"
 import { SignalOptions } from "../util/AbortController.ts"
@@ -15,7 +15,7 @@ export function tx(value: any) {
 }
 
 export class Tx<Y extends Yield, R extends Result> {
-  constructor(readonly f: Branch<Y, R>) {}
+  constructor(readonly f: Call<Y, R>) {}
 
   sign(senderSigner: SignBytes, ...maybeSigners: MaybeTxSigners<Y>): SignedTx<Y, R> {
     return new SignedTx(this, senderSigner, ...maybeSigners)

--- a/core/Bool.ts
+++ b/core/Bool.ts
@@ -1,17 +1,17 @@
 import { Tagged } from "../util/Tagged.ts"
 import { unimplemented } from "../util/unimplemented.ts"
-import { Branch, Result, Yield } from "./Branch.ts"
+import { Call, Result, Yield } from "./Call.ts"
 import { Effect } from "./Effect.ts"
 import { None } from "./None.ts"
 import { Type } from "./Type.ts"
 
 export class bool extends Type.make("bool")<BoolSource, boolean, never, never> {
-  if<R extends Result>(command: R | (() => R)): If<never, R>
+  if<R extends Result>(call: R | (() => R)): If<never, R>
   if<Y extends Yield, R extends Result>(
-    command: Generator<Y, R> | (() => Generator<Y, R>),
+    call: Generator<Y, R> | (() => Generator<Y, R>),
   ): If<Y, R>
-  if(command: any) {
-    return new If(this, command)
+  if(call: any) {
+    return new If(this, call)
   }
 
   not(): bool {
@@ -24,20 +24,20 @@ export class bool extends Type.make("bool")<BoolSource, boolean, never, never> {
 }
 
 export class If<Y extends Yield, R extends Result> extends Effect<Y, R | None> {
-  constructor(readonly self: bool, readonly command: Branch<Y, R>) {
+  constructor(readonly self: bool, readonly call: Call<Y, R>) {
     super()
-    const [yields, result] = Branch.collect(command)
+    const [yields, result] = Call.collect(call)
     this.yields = yields
     this.result = result
   }
 
   else<R2 extends Result>(
-    command: R2 | (() => R2),
+    call: R2 | (() => R2),
   ): [Y] extends [never] ? R | R2 : Effect<Y, R | R2>
   else<Y2 extends Yield, R2 extends Result>(
-    command: Generator<Y2, R2> | (() => Generator<Y2, R2>),
+    call: Generator<Y2, R2> | (() => Generator<Y2, R2>),
   ): Effect<Y | Y2, R | R2>
-  else(_command: any) {
+  else(_call: any) {
     return unimplemented()
   }
 }

--- a/core/Call.ts
+++ b/core/Call.ts
@@ -4,35 +4,35 @@ import { Type } from "./Type.ts"
 export type Yield = Type
 export type Result = Type | void
 
-export type ValueBranch<R, A extends unknown[]> = R | ((...args: A) => R)
+export type ValueCall<R, A extends unknown[]> = R | ((...args: A) => R)
 
-export type GenBranch<
+export type GenCall<
   Y extends Yield = any,
   R extends Result = any,
   A extends unknown[] = any,
 > = Generator<Y, R> | ((...args: A) => Generator<Y, R>)
 
-export type Branch<
+export type Call<
   Y extends Yield = any,
   R extends Result = any,
   A extends unknown[] = any,
-> = ValueBranch<R, A> | GenBranch<Y, R, A>
+> = ValueCall<R, A> | GenCall<Y, R, A>
 
-export namespace Branch {
+export namespace Call {
   export function collect<Y extends Yield, R extends Result>(
-    branch: Branch<Y, R>,
+    call: Call<Y, R>,
   ): G.Collected<Y, R> {
-    if (typeof branch === "function") {
-      const maybeGen = branch()
+    if (typeof call === "function") {
+      const maybeGen = call()
       if (typeof maybeGen === "object" && Symbol.iterator in maybeGen) {
         return G.collect(maybeGen)
       } else {
         return [[], maybeGen]
       }
-    } else if (typeof branch === "object" && Symbol.iterator in branch) {
-      return G.collect(branch)
+    } else if (typeof call === "object" && Symbol.iterator in call) {
+      return G.collect(call)
     } else {
-      return [[], branch]
+      return [[], call]
     }
   }
 }

--- a/core/Effect.ts
+++ b/core/Effect.ts
@@ -1,6 +1,6 @@
 import { Flatten } from "../util/Flatten.ts"
 import { unimplemented } from "../util/unimplemented.ts"
-import { GenBranch, Result, ValueBranch, Yield } from "./Branch.ts"
+import { GenCall, Result, ValueCall, Yield } from "./Call.ts"
 import { Factory } from "./Type.ts"
 import { ExtractUse, Use } from "./Use.ts"
 
@@ -36,11 +36,11 @@ export abstract class Effect<Y extends Yield, R extends Result> implements Gener
 
   handle<M extends Factory<Y>, R extends Result>(
     match: M,
-    f: ValueBranch<R, [value: InstanceType<M>]>,
+    f: ValueCall<R, [value: InstanceType<M>]>,
   ): [Exclude<Y, InstanceType<M>>] extends [never] ? R : Effect<Exclude<Y, InstanceType<M>>, R>
   handle<M extends Factory<Y>, Y2 extends Yield, R extends Result>(
     match: M,
-    f: GenBranch<Y2, R, [value: InstanceType<M>]>,
+    f: GenCall<Y2, R, [value: InstanceType<M>]>,
   ): [Exclude<Y, InstanceType<M>> | Y2] extends [never] ? R
     : Effect<Exclude<Y, InstanceType<M>> | Y2, R>
   handle(_match: any, _f: any): any {
@@ -56,14 +56,14 @@ export abstract class Effect<Y extends Yield, R extends Result> implements Gener
   }
 }
 
-export function branch<
+export function call<
   Y extends Yield,
   R extends Result,
   D extends ExtractUse<Y>,
   A extends Partial<D>,
   N extends Omit<D, keyof A>,
 >(
-  _branch: Generator<Y, R> | (() => Generator<Y, R>),
+  _call: Generator<Y, R> | (() => Generator<Y, R>),
   _uses: A,
 ): Effect<
   Exclude<Y, Use> | [keyof N] extends [never] ? never : Use<Flatten<N>>,

--- a/core/Id.ts
+++ b/core/Id.ts
@@ -21,10 +21,6 @@ export class id extends Type.make("id")<IdSource, Uint8Array, Uint8Array> {
     unimplemented()
   }
 
-  static fromBytes(_bytes: Uint8Array): id {
-    unimplemented()
-  }
-
   bind<N>(_namespace: N): Contract<N> {
     unimplemented()
   }

--- a/core/Type.ts
+++ b/core/Type.ts
@@ -2,7 +2,7 @@ import { Rest } from "../util/Rest.ts"
 import { Tagged } from "../util/Tagged.ts"
 import { unimplemented } from "../util/unimplemented.ts"
 import { bool, BoolSource } from "./Bool.ts"
-import { GenBranch, Result, ValueBranch, Yield } from "./Branch.ts"
+import { GenCall, Result, ValueCall, Yield } from "./Call.ts"
 import { Effect } from "./Effect.ts"
 import { State } from "./State.ts"
 
@@ -55,7 +55,7 @@ export class Type<
   >(
     this: T,
     match: M,
-    f: ValueBranch<R, [InstanceType<M>]>,
+    f: ValueCall<R, [InstanceType<M>]>,
   ): U
   match<
     T extends Type,
@@ -66,7 +66,7 @@ export class Type<
   >(
     this: T,
     match: M,
-    f: GenBranch<Y, R, [InstanceType<M>]>,
+    f: GenCall<Y, R, [InstanceType<M>]>,
   ): Effect<Y, U>
   match(_match: any, _f: any): any {
     unimplemented()

--- a/core/Use.ts
+++ b/core/Use.ts
@@ -2,17 +2,21 @@ import { Flatten } from "../util/Flatten.ts"
 import { Tagged } from "../util/Tagged.ts"
 import { U2I } from "../util/U2I.ts"
 import { unimplemented } from "../util/unimplemented.ts"
-import { Yield } from "./Branch.ts"
-import { Fields, FieldTypes } from "./Struct.ts"
-import { Type } from "./Type.ts"
+import { Yield } from "./Call.ts"
+import { Factory, Type } from "./Type.ts"
 
-export function use<F extends FieldTypes>(
-  _fields: F,
-): Generator<Use<Flatten<Fields<F>>>, Flatten<Fields<F>>> {
+export type UseField = Factory
+export type UseFieldTypes = Record<string, UseField>
+export type UseFields<F extends UseFieldTypes = any> = { [K in keyof F]: InstanceType<F[K]> }
+
+// TODO: defaults?
+export function use<F extends UseFieldTypes>(_fields: F): Generator<
+  Use<Flatten<UseFields<F>>>
+> {
   unimplemented()
 }
 
-export class Use<F extends Fields = any> extends Type.make("Dependencies")<UseSource> {
+export class Use<F extends UseFields = any> extends Type.make("Dependencies")<UseSource> {
   constructor(readonly fields: F) {
     super(new UseSource())
   }

--- a/core/mod.ts
+++ b/core/mod.ts
@@ -1,8 +1,8 @@
 // moderate --exclude Union.ts
 
 export * from "./Bool.ts"
-export * from "./Branch.ts"
 export * from "./Bytes.ts"
+export * from "./Call.ts"
 export * from "./Effect.ts"
 export * from "./Hash.ts"
 export * from "./Id.ts"

--- a/examples/Counter/Counter.contract.ts
+++ b/examples/Counter/Counter.contract.ts
@@ -4,8 +4,9 @@ export class Counter {
   count = L.u256.state();
 
   *increment() {
+    const { amount } = yield* L.use({ amount: L.u256 })
     const from = yield* this.count()
-    const to = from.add(L.u256.new(1))
+    const to = from.add(amount.match(L.None, L.u256.new(1)))
     yield IncrementedEvent.new({ from, to })
     return yield* this.count(to)
   }

--- a/examples/Counter/counter_deploy.ts
+++ b/examples/Counter/counter_deploy.ts
@@ -8,12 +8,10 @@ const [contract, sender] = signer(2)
 await L
   .tx(
     L.id
-      .fromBytes(contract.publicKey)
+      .new(contract.publicKey)
       .signer("contract")
       .deploy(new Counter(), {
-        state: {
-          count: L.u256.new(1),
-        },
+        state: { count: L.u256.new(1) },
       }),
   )
   .sign(sender, { contract })

--- a/examples/MinaFungibleToken/MinaFungibleToken.contract.ts
+++ b/examples/MinaFungibleToken/MinaFungibleToken.contract.ts
@@ -8,12 +8,12 @@ export function* transfer(to: L.id, amount: L.u256) {
   const balances = yield* balances_()
   const updatedSenderBalance = yield* balances
     .get(L.sender)
-    .match(L.None, InsufficientBalanceError.new())
     .match(L.u256, (balance) =>
       balance
         .gte(amount)
         .if(balance.subtract(amount))
         .else(InsufficientBalanceError.new()))
+    .match(L.None, InsufficientBalanceError.new())
     ["?"](InsufficientBalanceError)
   const updatedToBalance = balances
     .get(to)

--- a/examples/call.ts
+++ b/examples/call.ts
@@ -14,7 +14,7 @@ add satisfies () => Generator<
   unknown
 >
 
-const partial = L.branch(add, {
+const partial = L.call(add, {
   a: L.u256.new(0),
 })
 
@@ -27,7 +27,7 @@ partial satisfies L.Effect<
   L.u256
 >
 
-const final = L.branch(partial, {
+const final = L.call(partial, {
   b: L.u256.new(0),
 })
 

--- a/experiments/playground.ts
+++ b/experiments/playground.ts
@@ -2,5 +2,5 @@ import { Counter } from "../examples/Counter/Counter.contract.ts"
 import * as L from "../mod.ts"
 
 const counter = new Counter()
-const normalized = L.Branch.collect(counter.increment.bind(counter))
+const normalized = L.Call.collect(counter.increment.bind(counter))
 console.log(normalized)

--- a/util/Rest.ts
+++ b/util/Rest.ts
@@ -1,1 +1,1 @@
-export type Rest<T> = T extends undefined ? [] : undefined extends T ? [value?: T] : [value: T]
+export type Rest<T> = undefined extends T ? [value?: T] : [value: T]


### PR DESCRIPTION
- rename `Branch` to `Call`
- fix `Rest` type for correct signature in `Type.new` param