### PR TITLE
Disable `yield`ing State

### DIFF
--- a/Design.md
+++ b/Design.md
@@ -1,6 +1,4 @@
-# TODO
-
-## Design thoughts
+# Misc. Design Thoughts
 
 - Should be able to plainly see which keys correspond to required signatures, hence the difference
   between the id and signer type
@@ -12,8 +10,8 @@
   effect, you’ll get a compilation error.
 - Just a description. Not the execution. We want to compile this into a minimal metadata format from
   which we can derive circuits.
-- Doc comments flow through the experience
-- State update preconditions are derived from assertions
+- Doc comments flow through the contract authoring experience all the way to the client experience
+- State update preconditions are derived from assertions / yields
 - Generators are quite nice, as they establish a secondary channel (the yield channel). This enables
   type safe modeling of functional effects.
 - Another benefit of this: one can describe signer requirements in such a way that they’re
@@ -33,54 +31,4 @@
 - In T6's words: "the yield* indicates 'hey, an effect is being used here'"
 - should `Struct` instead be `Event`? We'll never opt to use a `Struct` if we don't have to / would
   prefer TS interfaces / JS objects
-
-———
-
-- tsconfig paths mapping. Swc register does this, but esm sourcemapping is broken. Meanwhile
-  ts-node's accompanying tsconfig-paths lib is incompatible with --import approach. Seemingly
-  unmaintained.
-
-- default values
-
-- make everything `yield*`able
-
-- merkle map/list equality checks, slicing
-
-How do we deal with tipping within the tx generator? Ideally we could use different tips for
-different calls, no?
-
-Merkle list+map impls
-
-Batch set
-
-Can we do away with account updates?
-
-Implicit type conversion in misc. methods. Ie.
-
-Custom inspect
-
-Fallible from? For instance a u16 to a u8, where there is a runtime check for overflowing
-
-```ts
-add(value: this | Type.From<this>): this {
-  return new AddNode(this, value).instance()
-}
-```
-
-<!--
-
-Be consistent about convention around type names/tags/misc.
-
-// trap
-// deps
-// sign
-// event
-
--->
-
-// if you don't yield, it's effectively meta-programming
-
-Structure:
-
-- why generators?
-- ids and signers
+- If you don't yield, it's effectively meta-programming

--- a/core/Id.ts
+++ b/core/Id.ts
@@ -92,6 +92,9 @@ export interface SendProps {
 }
 
 // TODO
-export type Contract<T> = id & T & {
-  store(store: Store): Contract<T>
-}
+export type Contract<T> =
+  & id
+  & { [K in keyof T]: T[K] extends State<infer S> ? S : T[K] }
+  & {
+    store(store: Store): Contract<T>
+  }

--- a/core/State.ts
+++ b/core/State.ts
@@ -2,8 +2,7 @@ import { Effect } from "./Effect.ts"
 import { Factory, Type } from "./Type.ts"
 
 export type State<T extends Type = any> = {
-  (): Effect<never, T>
-  (setter: StateSetter<T>): Effect<never, T>
+  (setter: StateSetter<T>): Effect<never, never>
   tag: "State"
   type: Factory<T>
 }
@@ -18,12 +17,11 @@ export function State<T extends Type>(type: Factory<T>): State<T> {
   return state
 }
 
-export class StateEffect<T extends Type> extends Effect<never, T> {
+export class StateEffect<T extends Type> extends Effect<never, never> {
   declare setter?: StateSetter<T>
   constructor(readonly state: State<T>, setter?: StateSetter<T>) {
     super()
     this.yields = [this as never]
-    this.result = new state.type(this)
     if (setter) this.setter = setter
   }
 }

--- a/examples/Counter/counter_interact.ts
+++ b/examples/Counter/counter_interact.ts
@@ -8,7 +8,7 @@ const sender = signer()
 const finalization = await L
   .tx(function*() {
     const counter = L.id.fromHex(Deno.env.get("COUNTER_ID")!).bind(Counter)
-    const initial = yield* counter.count_()
+    const initial = counter.count_
     yield* counter.increment({ amount: L.none })
     yield* counter.increment({ amount: L.none })
     yield* counter.increment({ amount: L.none })

--- a/examples/Erc20/extensions/Erc20Metadata.contract.ts
+++ b/examples/Erc20/extensions/Erc20Metadata.contract.ts
@@ -5,16 +5,10 @@ export const symbol_ = L.String.state()
 export const decimals_ = L.u8.state()
 
 // https://github.com/OpenZeppelin/openzeppelin-contracts/blob/52c36d412e8681053975396223d0ea39687fe33b/contracts/token/ERC20/extensions/IERC20Metadata.sol#L15
-export function name() {
-  return name_()
-}
+export const name = L.f({ name_ }, ({ name_ }) => name_)
 
 // https://github.com/OpenZeppelin/openzeppelin-contracts/blob/52c36d412e8681053975396223d0ea39687fe33b/contracts/token/ERC20/extensions/IERC20Metadata.sol#L20
-export function symbol() {
-  return symbol_()
-}
+export const symbol = L.f({ symbol_ }, ({ symbol_ }) => symbol_)
 
 // https://github.com/OpenZeppelin/openzeppelin-contracts/blob/52c36d412e8681053975396223d0ea39687fe33b/contracts/token/ERC20/extensions/IERC20Metadata.sol#L25
-export function decimals() {
-  return decimals_()
-}
+export const decimals = L.f({ decimals_ }, ({ decimals_ }) => decimals_)


### PR DESCRIPTION
Getting rid of the following...

```ts
const state_ = L.u8.state()

function* x() {
  const state = yield* state_()
  // ...
}
```

In favor of...

```ts
const state_ = L.u8.state()

const x = L.f({state_}, function*({ state_ }) {
  // ...
})
```