### PR TITLE
Effect-related Cleanup

### DIFF
--- a/core/Effect.ts
+++ b/core/Effect.ts
@@ -1,14 +1,10 @@
 import { unimplemented } from "../util/unimplemented.ts"
-import { GenCall, Result, ValueCall, Yield } from "./Call.ts"
+import { Call, GenCall, Result, ValueCall, Yield } from "./Call.ts"
 import { Factory, Type } from "./Type.ts"
 
 export abstract class Effect<Y extends Yield, R extends Result> implements Generator<Y, R> {
   declare yields?: Y[]
   declare result?: R
-
-  map<R2 extends Result>(_f: (value: R) => R2): Effect<Y, R2> {
-    unimplemented()
-  }
 
   next(): IteratorResult<Y, R> {
     unimplemented()
@@ -46,24 +42,29 @@ export abstract class Effect<Y extends Yield, R extends Result> implements Gener
     return unimplemented()
   }
 
-  handle<M extends Factory<Y>, R extends Result>(
+  catch<
+    M extends Factory<Y>,
+    R2 extends Result,
+  >(
     match: M,
-    f: ValueCall<R, [value: InstanceType<M>]>,
-  ): [Exclude<Y, InstanceType<M>>] extends [never] ? R : Effect<Exclude<Y, InstanceType<M>>, R>
-  handle<M extends Factory<Y>, Y2 extends Yield, R extends Result>(
+    f: ValueCall<R2, [InstanceType<M>]>,
+  ): Effect<Exclude<Y, InstanceType<M>>, R | R2>
+  catch<
+    M extends Factory<Y>,
+    Y2 extends Yield,
+    R2 extends Result,
+  >(
     match: M,
-    f: GenCall<Y2, R, [value: InstanceType<M>]>,
-  ): [Exclude<Y, InstanceType<M>> | Y2] extends [never] ? R
-    : Effect<Exclude<Y, InstanceType<M>> | Y2, R>
-  handle(_match: any, _f: any): any {
-    unimplemented()
-  }
-
-  rehandle<M extends Factory[]>(
-    ..._match: M
-  ): [Exclude<Y, InstanceType<M[number]>>] extends [never] ? Extract<Y, InstanceType<M[number]>> | R
-    : Effect<Exclude<Y, InstanceType<M[number]>>, R>
-  {
+    f: GenCall<Y, R2, [InstanceType<M>]>,
+  ): Effect<Exclude<Y, InstanceType<M>> | Y2, R | R2>
+  catch<
+    M extends Factory<Y>,
+    Y2 extends Yield,
+    R2 extends Result,
+  >(
+    _match: M,
+    _f: Call<Y, R2, [InstanceType<M>]>,
+  ): Effect<Exclude<Y, InstanceType<M>> | Y2, R | R2> {
     unimplemented()
   }
 }

--- a/examples/control_flow.ts
+++ b/examples/control_flow.ts
@@ -24,12 +24,8 @@ declare const maybe: L.u8 | L.None
   effect satisfies L.Effect<L.None, L.u8>
 
   // Handle values that were yielded from the call that produced the effect.
-  const handled = effect.handle(L.None, L.u8.new(0))
-  handled satisfies L.u8
-
-  // Match and move an effect's yielded value back to the result channel.
-  const rehandled = effect.rehandle(L.None)
-  rehandled satisfies L.u8 | L.None
+  const handled = effect.catch(L.None, L.u8.new(0))
+  handled satisfies L.Effect<L.None, L.u8>
 }
 
 {


### PR DESCRIPTION
- removes `handle`/`unhandle`/`rehandle` methods
- introduces `catch`

This is more practical in the context of generators, where one likely wants to re-yield the values of a given effect-producing call, or handle specific yielded values to produce a result. Ie.

```ts
const maybeAdd = L.f({
  a: L.Union(L.u8, L.None),
  b: L.u8,
}, function*({ a, b }) {
  const v = yield* a["?"](L.None)
  return v.add(b)
})

const usesMaybeAdd = L.f(function*() {
  const c = yield* maybeAdd({
    a: L.None,
    b: L.u8.new(1),
  }).catch(L.None, L.u8.new(0))
})
```

In this case, `usesMaybeAdd` calls `maybeAdd`, a function which could produce an `L.None`-yielding effect. We `catch` this case and supplement a `u8`. We could instead supplement a different value if we wanted.

```diff
const usesMaybeAdd = L.f(function*() {
  const c = yield* maybeAdd({
    a: L.None,
    b: L.u8.new(1),
- }).catch(L.None, L.u8.new(0))
+ }).catch(L.None, L.u16.new(0))
})
```

The resulting signature of `c` would then be `L.u8 | L.u16`.

This approach makes sense given that most yields should be re-yielded (signer requirements and structs for example).