### PR TITLE
`match` on `Effect`

### DIFF
--- a/core/Effect.ts
+++ b/core/Effect.ts
@@ -28,6 +28,23 @@ export abstract class Effect<Y extends Yield, R extends Result> implements Gener
     return result
   }
 
+  match<T extends Type<R>, R2 extends Result>(
+    match: T,
+    f: ValueCall<R2, [InstanceType<T>]>,
+  ): Effect<Y, Exclude<R, InstanceType<T>> | R2>
+  match<T extends Type<R>, Y2 extends Yield, R2 extends Result>(
+    this: Effect<Y, R>,
+    match: T,
+    f: GenCall<Y2, R2, [InstanceType<T>]>,
+  ): Effect<Y | Y2, Exclude<R, InstanceType<T>> | R2>
+  match<T extends Type<R>, Y2 extends Yield, R2 extends Result>(
+    this: Effect<Y, R>,
+    _match: T,
+    _f: Call<Y2, R2, [InstanceType<T>]>,
+  ): Effect<Y | Y2, Exclude<R, InstanceType<T>> | R2> {
+    unimplemented()
+  }
+
   "?"<M extends Type<Exclude<R, void>>>(
     match: M,
   ): Effect<Y | InstanceType<M>, Exclude<R, InstanceType<M>>>

--- a/core/Value.ts
+++ b/core/Value.ts
@@ -3,11 +3,12 @@ import { Setter } from "../util/Setter.ts"
 import { Tagged } from "../util/Tagged.ts"
 import { unimplemented } from "../util/unimplemented.ts"
 import { bool, BoolSource } from "./Bool.ts"
-import { GenCall, Result, ValueCall, Yield } from "./Call.ts"
+import { Call, GenCall, Result, ValueCall, Yield } from "./Call.ts"
 import { Effect } from "./Effect.ts"
 import { Union, UnionCtor } from "./Union.ts"
 
-export type Type<T extends Value = any> = new(source: any) => T
+// TODO: is this void exclusion cursed?
+export type Type<T extends Value | void = any> = new(source: any) => Exclude<T, void>
 
 export class Value<
   Name extends string = any,
@@ -92,7 +93,17 @@ export class Value<
     match: M,
     f: GenCall<Y, R, [InstanceType<M>]>,
   ): Effect<Y, U>
-  match(_match: any, _f: any): any {
+  match<
+    T extends Value,
+    M extends Type<T>,
+    Y extends Yield,
+    R extends Result,
+    U extends Exclude<T, InstanceType<M>> | R,
+  >(
+    this: T,
+    _match: M,
+    _f: Call<Y, R, [InstanceType<M>]>,
+  ): U | Effect<Y, U> {
     unimplemented()
   }
 

--- a/examples/control_flow.ts
+++ b/examples/control_flow.ts
@@ -26,6 +26,9 @@ declare const maybe: L.u8 | L.None
   // Handle values that were yielded from the call that produced the effect.
   const handled = effect.catch(L.None, L.u8.new(0))
   handled satisfies L.Effect<L.None, L.u8>
+
+  const matched = handled.match(L.u8, L.u256.new(1))
+  matched satisfies L.Effect<never, L.u256>
 }
 
 {


### PR DESCRIPTION
Following this PR, one doesn't need to `yield*` an effect in order to match on its return value. Simplifies chaining in cases such as the following.

```diff
declare const effect: L.Effect<SignerRequirement<"A">, L.u8 | L.None>

function* x() {
- const x = yield* effect
- const y = x.match(L.None, L.u8.new(1))
+ const y = yield* effect.match(L.None, L.u8.new(1))
}
```